### PR TITLE
Small change to the language in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Each year, [ROS 2](https://docs.ros.org/en/rolling/) is released on [World Turtle Day](https://www.worldturtleday.org/).
 For every ROS 2 release, the [ROS 2 TSC](https://docs.ros.org/en/rolling/Governance.html) votes on the [default RMW](https://docs.ros.org/en/rolling/Concepts/About-Different-Middleware-Vendors.html) for the release.
 In order for the TSC to make an informed decision, [Open Robotics](https://www.openrobotics.org/) produces a report on the state of the available RMWs.
-The list below links to the available reports.
+The list below links to each of the available reports.
 
 ## Reports
 


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

The only real reason for this is to cause GitHub to regenerate the pages, so that it fixes a typo in the description.